### PR TITLE
fix: Repository link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@ html:
 
   # Information about where the book exists on the web
 repository:
-  url                       : https://dmol.pub  # Online location of your book
+  url                       : https://github.com/whitead/dmol-book  # Online location of your book
 
 launch_buttons:
   colab_url: "https://colab.research.google.com"


### PR DESCRIPTION
This url refers to the source repository shown in the top bar under the github icon (as in the official doc https://github.com/executablebooks/jupyter-book/blob/master/docs/_config.yml#L28).