### PR TITLE
fixed ml typo

### DIFF
--- a/ml/regression.ipynb
+++ b/ml/regression.ipynb
@@ -411,7 +411,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This is an overfit model. The training loss went down (note the noise was the same in the previous two examples), but at the expense of a large decrease in testing loss. This wasn't possible in the previous example because over-fitting to noise wasn't feasible when each feature was necessary to capture the correlation with the labels. \n",
+    "This is an overfit model. The training loss went down (note the noise was the same in the previous two examples), but at the expense of a large increase in testing loss. This wasn't possible in the previous example because over-fitting to noise wasn't feasible when each feature was necessary to capture the correlation with the labels. \n",
     "\n",
     "Let's see an example where the feature number is the same but they aren't perfectly correlated with labels, meaning we cannot match the labels even if there was no noise. "
    ]


### PR DESCRIPTION
Originally it said that overfitting resulted in a decrease in test loss. This changes it to an "increase" in test loss