### PR TITLE
Fix XAI chapter models and examples

### DIFF
--- a/dl/xai.ipynb
+++ b/dl/xai.ipynb
@@ -424,11 +424,13 @@
    "outputs": [],
    "source": [
     "epochs = 32\n",
+    "step = 0\n",
     "for e in range(epochs):\n",
     "    avg_v = 0\n",
-    "    for i, (xi, yi) in enumerate(batch_iter(train_x, train_y, batch_size, shuffle=True)):\n",
-    "        v, opt_state = update(i, opt_state, xi, yi)\n",
+    "    for xi, yi in batch_iter(train_x, train_y, batch_size, shuffle=True):\n",
+    "        v, opt_state = update(step, opt_state, xi, yi)\n",
     "        avg_v += v\n",
+    "        step += 1\n",
     "opt_params = get_params(opt_state)\n",
     "\n",
     "\n",
@@ -456,7 +458,7 @@
     "one-hots and sequence models.\n",
     "```\n",
     "\n",
-    "Let's try an amino acid sequence, a peptide, to get a feel for the model. The model outputs logits (logarithm of odds), which we put through a sigmoid to get probabilities. The peptides must be converted from a sequence to a matrix of one-hot column vectors. We'll try two known sequences: Q is known to be common in hemolytic residues and the second sequence is poly-G, which is the simplest amino acid."
+    "Let's try some amino acid sequences to get a feel for the model. The model outputs logits (logarithm of odds), which we put through a sigmoid to get probabilities. The peptides must be converted from a sequence to a matrix of one-hot column vectors. We'll try two sequences from the dataset: one labeled hemolytic and one non-hemolytic."
    ]
   },
   {
@@ -465,12 +467,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s = \"QQQQQ\"\n",
+    "s = \"LPRGIADLTENGAYQ\"\n",
     "sm = array2oh(seq2array(s))\n",
     "p = predict_prob(sm)\n",
     "print(f\"Probability {s} of being hemolytic {p:.2f}\")\n",
     "\n",
-    "s = \"GGGGG\"\n",
+    "s = \"IKITTMLAKLGKVLAHV\"\n",
     "sm = array2oh(seq2array(s))\n",
     "p = predict_prob(sm)\n",
     "print(f\"Probability {s} of being hemolytic {p:.2f}\")"
@@ -480,10 +482,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It looks reasonable -- the model matches our intuition about these two sequences\n",
-    "\n",
-    "\n",
-    "Now we compute the accuracy of our model, which is quite good. "
+    "The model correctly identifies the hemolytic peptide with high probability and the non-hemolytic one with low probability. Now we compute the accuracy of our model, which is quite good."
    ]
   },
   {
@@ -504,7 +503,7 @@
    "source": [
     "### Gradients\n",
     "\n",
-    "Now to start examining *why* a particular sequence is hemolytic! We'll begin by computing the gradients with respect to input -- the naieve approach that is susceptible to shattered gradients. Computing this is a component in the process for integrated and smooth gradients, so not wasted effort. We will use a more complex peptide sequence that is known to be hemolytic to get more interesting analysis. "
+    "Now to start examining *why* a particular sequence gets its prediction! We'll begin by computing the gradients with respect to input -- the naieve approach that is susceptible to shattered gradients. Computing this is a component in the process for integrated and smooth gradients, so not wasted effort. We will use a more complex peptide sequence to get more interesting analysis."
    ]
   },
   {
@@ -567,7 +566,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Remember that the model outputs logits. Positive value of the gradient mean this amino acid is responsible for pushing hemolytic probability higher and negative values mean the amino acid is pushing towards non-hemolytic. Interestingly, you can see a strong position dependence on the leucine (L) and arginine (R).\n",
+    "Remember that the model outputs logits. Positive value of the gradient mean this amino acid is responsible for pushing hemolytic probability higher and negative values mean the amino acid is pushing towards non-hemolytic. You can see position dependence -- the same amino acid type at different positions can have different importance.\n",
     "\n",
     "### Integrated Gradients\n",
     "\n",
@@ -720,7 +719,7 @@
     "\n",
     "\n",
     "# assume data is already shuffled, so just take M\n",
-    "M = 512\n",
+    "M = 1024\n",
     "sl = len(s)\n",
     "sampled_x = train_x[:M]\n",
     "# make batched shapley so we can compute for all features\n",
@@ -855,9 +854,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As someone who works with peptides, I believe the Shapley is the most accurate here. I wouldn't expect the pattern of L and R to be that significant, which is what the Shapley values show. Another difference is that the Shapley values do not show the phenylalanine (F) as have a significant effect. \n",
+    "As someone who works with peptides, I believe the Shapley values are the most accurate here. Shapley values tend to give a smoother, more balanced view of feature importance than raw gradients.\n",
     "\n",
-    "What can we conclude from this information? We could perhaps add an explanation like this: \"The sequence is predicted to be hemolytic primarily because of the glutamine, proline, and arrangement of lecucine and arginine.\"\n",
+    "What can we conclude from this information? We could perhaps add an explanation like this: \"The sequence is predicted to be hemolytic primarily because of specific amino acid identities and their positions in the sequence.\"\n",
     "\n",
     "## What is feature importance for?\n",
     "\n",
@@ -984,7 +983,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we'll display all the single amino acid substitutions which resulted in a negative prediction - the logits are less than zero."
+    "Now we'll display all the single amino acid substitutions which resulted in a flipped prediction -- crossing the decision boundary (logits = 0)."
    ]
   },
   {
@@ -995,8 +994,13 @@
    "source": [
     "from IPython.display import display, HTML\n",
     "\n",
+    "base_logit = predict(sm)\n",
     "out = [\"<tt>\"]\n",
-    "for i, j in zip(ii[jnp.squeeze(x) < 0], jj[jnp.squeeze(x) < 0]):\n",
+    "if base_logit >= 0:\n",
+    "    mask = jnp.squeeze(x) < 0\n",
+    "else:\n",
+    "    mask = jnp.squeeze(x) >= 0\n",
+    "for i, j in zip(ii[mask], jj[mask]):\n",
     "    out.append(f'{s[:i]}<span style=\"color:red;\">{ALPHABET[j]}</span>{s[i+1:]}<br/>')\n",
     "out.append(\"</tt>\")\n",
     "display(HTML(\"\".join(out)))"
@@ -1006,7 +1010,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We have a few to choose from, but the interpretation is essentially exchange the glutamine with a hydrophobic group or replace the proline with V, F, A, or C to make the peptide non-hemolytic. Stated as a counterfactual: \"If the glutamine were exchanged with a hydrophobic amino acid, the peptide would not be hemolytic\"."
+    "These are the counterfactual substitutions -- single amino acid changes that flip the model's prediction. Each line shows the original sequence with the substituted amino acid highlighted in red. The counterfactuals reveal which positions and amino acid identities are most sensitive for the model's decision boundary."
    ]
   },
   {
@@ -1121,8 +1125,9 @@
     "# Convert to numeric, coercing errors to NaN\n",
     "features = features.apply(pd.to_numeric, errors=\"coerce\")\n",
     "# Standardize the features\n",
-    "features -= features.mean()\n",
-    "features /= features.std()\n",
+    "feat_mean = features.mean()\n",
+    "feat_std = features.std()\n",
+    "features = (features - feat_mean) / feat_std\n",
     "\n",
     "# we have some nans in features, likely because std was 0\n",
     "features = features.values.astype(float)\n",
@@ -1231,6 +1236,8 @@
     "def model_eval(smiles, selfies):\n",
     "    molecules = [rdkit.Chem.MolFromSmiles(smi) for smi in smiles]\n",
     "    feat = calc.pandas(molecules)\n",
+    "    feat = feat.apply(pd.to_numeric, errors=\"coerce\")\n",
+    "    feat = (feat - feat_mean) / feat_std\n",
     "    feat = feat.values.astype(float)\n",
     "    feat = feat[:, features_select]\n",
     "    with torch.no_grad():\n",


### PR DESCRIPTION
## Summary
- **Fix Adam training loop bug**: step counter was resetting each epoch, corrupting bias correction. Now uses cumulative step counter.
- **Fix exmol standardization**: save `feat_mean`/`feat_std` and apply in `model_eval` so inference matches training pipeline (root cause of single-class predictions).
- **Replace toy peptides with real examples**: QQQQQ/GGGGG were out-of-distribution and produced wrong predictions. Now uses actual dataset sequences (LPRGIADLTENGAYQ, IKITTMLAKLGKVLAHV).
- **Robust counterfactual display**: cell 48 now dynamically detects base prediction direction and finds label-flipping substitutions.
- **Double Shapley sample count**: 512 → 1024 for better convergence.
- **Update narrative text** to match actual model behavior.

## Test plan
- [x] Build book with only XAI chapter (`jupyter-book build --all .`)
- [x] Verify LPRGIADLTENGAYQ → 1.00 (hemolytic), IKITTMLAKLGKVLAHV → 0.00 (non-hemolytic)
- [x] Verify test accuracy > 0.8 (actual: 0.936)
- [x] Verify cell 48 shows focused counterfactual list (5 substitutions)
- [x] Verify tox model accuracy prints reasonable % (93.92%)
- [x] Verify `exmol.cf_explain` returns counterfactuals with different predicted class
- [x] Verify counterfactual plot renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)